### PR TITLE
Update repository for Python 3.12

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,8 +60,8 @@ Crossbar
 ^^^^^^^^^^^^^^^^^^^^^
 Install crossbar on the Iotronic host::
 
-    apt install python-pip python3-pip libsnappy-dev libssl-dev libffi-dev python-dev
-    pip3 install python-snappy crossbar
+    apt install python3-pip libsnappy-dev libssl-dev libffi-dev python3-dev
+    pip install python-snappy crossbar
 
 Configuration::
 
@@ -157,8 +157,8 @@ add the user iotronic::
 and Iotronic::
 
     cd iotronic
-    pip3 install -r requirements.txt 
-    python3 setup.py install
+    pip install -r requirements.txt
+    python setup.py install
 
 create a log dir::
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,9 +15,7 @@ classifier =
     Operating System :: POSIX :: Linux
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.12
 
 [entry_points]
 console_scripts =

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,10 @@
 [tox]
 minversion = 2.3.1
-envlist = py36,py37,py38,pep8
+envlist = py312,pep8
 skipsdist = True
 
 [testenv]
+basepython = python3.12
 setenv =
     VIRTUAL_ENV={envdir}
     PYTHONWARNINGS=default::DeprecationWarning
@@ -19,7 +20,7 @@ commands =
     find . -type f -name "*.pyc" -delete
 
 [testenv:pep8]
-basepython = python3.8
+basepython = python3.12
 #commands = /usr/local/bin/flake8 {posargs}
 commands = flake8 {posargs}
 
@@ -27,25 +28,20 @@ commands = flake8 {posargs}
 commands = {posargs}
 
 [testenv:cover]
-commands = python3 setup.py test --coverage --testr-args='{posargs}'
+commands = python setup.py test --coverage --testr-args='{posargs}'
 
 [testenv:docs]
 commands =
   rm -fr doc/build
-  python3 setup.py build_sphinx
+  python setup.py build_sphinx
 
 [testenv:releasenotes]
 commands =
   sphinx-build -a -E -W -d releasenotes/build/doctrees -b html releasenotes/source releasenotes/build/html
 
-[testenv:py36]
-basepython = python3.6
 
-[testenv:py37]
-basepython = python3.7
-
-[testenv:py38]
-basepython = python3.8
+[testenv:py312]
+basepython = python3.12
 
 [flake8]
 # TODO(dmllr): Analyze or fix the warnings blacklisted below

--- a/zuul.d/projects.yaml
+++ b/zuul.d/projects.yaml
@@ -1,7 +1,5 @@
 - project:
     templates:
-      - openstack-python38-jobs-no-constraints
-      - openstack-python37-jobs-no-constraints
-      - openstack-python36-jobs-no-constraints
+      - openstack-python3-jobs-no-constraints
       - check-requirements
       - publish-to-pypi


### PR DESCRIPTION
## Summary
- drop legacy Python versions
- switch tox configuration and CI jobs to Python 3.12
- update README installation instructions

## Testing
- `pip install tox` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6883fa14cd048332a7a8c09432a54ed2